### PR TITLE
Rotem/bugfix/mobile 1073/crash on sso jwt

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -19,12 +19,75 @@ export default class App extends Component<{}> {
     }
     const subscription = SpotIMEventEmitter.addListener('startLoginFlow', onStartLoginFlow);
 
+    // SPOT IM INIT
+    // SpotIMAPI.init(SPOT_ID);
+    
+    // COMPLETE SSO FLOW
+    // SpotIMAPI.startSSO()
+    // .then((data) => {
+    //   console.log("Succees for SSO: ");
+    //   console.log("Code: " + data.codeA);
+    //   console.log("token: " + data.jwtToken);
+
+    //   const Http = new XMLHttpRequest();
+    //   const url=SSO_ENDPOINT;
+    //   Http.open("POST", url);
+    //   Http.setRequestHeader("access-token-network", SPOT_ACCESS_TOKEN);
+    //   Http.setRequestHeader("content-type","application/json");
+    //   Http.send(JSON.stringify({
+    //     "code_a":data.codeA,
+    //     "access_token":data.jwtToken,
+    //     "username":"test",
+    //     "environment":"production"
+    //   }));
+    //   Http.onreadystatechange=(e) => {
+    //     const json = JSON.parse(Http.responseText);
+    //     SpotIMAPI.completeSSO(json.code_b)
+    //     .then((response) => {
+    //       console.log(response.success);
+    //     })
+    //     .catch((error) => {
+    //       console.log(error);
+    //     })
+    //   }
+    // })
+    // .catch((error) => {
+    //   console.log("Api call error: " + error);
+    // });
+
+    // SSO WITH JWT
+    // const result = SpotIMAPI.sso(JWT_TOKEN)
+    // .then((data) => {
+    //   console.log("Succees for SSO: ");
+    //   console.log(data.success);
+    // }).catch((error)=>{
+    //    console.log("Api call error");
+    // });
+  
+    // LOGOUT
+    // SpotIMAPI.logout()
+    // .then((response) => {
+    //   console.log("Logout success: " + response.success);
+    // })
+    // .catch((error) => {
+    //   console.log("Logout error: " + error);
+    // });
+
+    // // GET USER STATUS
+    // SpotIMAPI.getUserLoginStatus()
+    // .then((response) => {
+    //   console.log("User status is: " + response.status);
+    // })
+    // .catch((error) => {
+    //   console.log("User status error: ");
+    //   console.log(error);
+    // });
     return (
       <ScrollView style={styles.container}>
         <Text style={styles.welcome}>Spot.IM React-Native Demo App</Text>
         <Text>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</Text>
         <SpotIM
-          spotId="sp_eCIlROSD"
+          spotId="sp_ANQXRpqH"
           postId="sdk1"
           url="http://www.spotim.name/bd-playground/post9.html"
           title="Spot.IM is aiming for the stars!"

--- a/example/App.js
+++ b/example/App.js
@@ -22,46 +22,67 @@ export default class App extends Component<{}> {
     // SPOT IM INIT
     // SpotIMAPI.init(SPOT_ID);
     
-    // COMPLETE SSO FLOW
-    // SpotIMAPI.startSSO()
-    // .then((data) => {
-    //   console.log("Succees for SSO: ");
-    //   console.log("Code: " + data.codeA);
-    //   console.log("token: " + data.jwtToken);
 
-    //   const Http = new XMLHttpRequest();
-    //   const url=SSO_ENDPOINT;
-    //   Http.open("POST", url);
-    //   Http.setRequestHeader("access-token-network", SPOT_ACCESS_TOKEN);
-    //   Http.setRequestHeader("content-type","application/json");
-    //   Http.send(JSON.stringify({
-    //     "code_a":data.codeA,
-    //     "access_token":data.jwtToken,
-    //     "username":"test",
-    //     "environment":"production"
-    //   }));
-    //   Http.onreadystatechange=(e) => {
+    // COMPLETE SSO FLOW
+    // const Http = new XMLHttpRequest();
+    // const url=SSO_ENDPOINT_BASE_URL+SSO_ENDPOINT_LOGIN;
+    // Http.open("POST", url);
+    // Http.setRequestHeader("content-type","application/json");
+    // Http.send(JSON.stringify({
+    //   "username":USERNAME,
+    //   "password":PASSWORD
+    // }));
+    // Http.onreadystatechange=(e) => {
+    //   if(Http.readyState == 4) {
+    //     console.log(Http.responseText);
     //     const json = JSON.parse(Http.responseText);
-    //     SpotIMAPI.completeSSO(json.code_b)
-    //     .then((response) => {
-    //       console.log(response.success);
+    //     const userToken = json.token
+    //     console.log("user token: " + userToken);
+    //     SpotIMAPI.startSSO()
+    //     .then((data) => {
+    //       console.log("SpotIm: Succees for SSO: ");
+    //       console.log("SpotIm: Code: " + data.code_a);
+
+    //       const Http = new XMLHttpRequest();
+    //       const url=SSO_ENDPOINT_BASE_URL+SSO_ENDPOINT_CODE_B;
+    //       Http.open("POST", url);
+    //       Http.setRequestHeader("access-token-network", SPOT_ACCESS_TOKEN);
+    //       Http.setRequestHeader("content-type","application/json");
+    //       Http.send(JSON.stringify({
+    //         "code_a":data.code_a,
+    //         "access_token":userToken,
+    //         "username":USERNAME,
+    //         "environment":"production"
+    //       }));
+    //       Http.onreadystatechange=(e) => {
+    //         if(Http.readyState == 4) {
+    //           const json = JSON.parse(Http.responseText);
+    //           console.log("Got code B: ");
+    //           console.log(json)
+    //           SpotIMAPI.completeSSO(json.code_b)
+    //           .then((response) => {
+    //             console.log("SpotIm: " + response.success);
+    //           })
+    //           .catch((error) => {
+    //             console.log("SpotIm: " + error);
+    //           })
+    //         }        
+    //       } 
     //     })
     //     .catch((error) => {
-    //       console.log(error);
-    //     })
+    //       console.log("SpotIm: Api call error: " + error);
+    //     });
     //   }
-    // })
-    // .catch((error) => {
-    //   console.log("Api call error: " + error);
-    // });
+    // }
+    
 
     // SSO WITH JWT
-    // const result = SpotIMAPI.sso(JWT_TOKEN)
+    // SpotIMAPI.sso(JWT_TOKEN)
     // .then((data) => {
     //   console.log("Succees for SSO: ");
     //   console.log(data.success);
     // }).catch((error)=>{
-    //    console.log("Api call error");
+    //   console.log("Api call error: " + error.error);
     // });
   
     // LOGOUT

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -228,9 +228,9 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-spotim (1.0.7):
+  - react-native-spotim (1.0.13-rc.1):
     - React
-    - SpotIMCore
+    - SpotIMCore (~> 1.0)
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
   - React-RCTAnimation (0.63.2):
@@ -422,7 +422,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-spotim: 7f85a4f154b5f5d6cf5fbbc7915ca43ab9a5dd24
+  react-native-spotim: a0f239043c655138f74d2d9d96e64914f7f7cfeb
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2325,9 +2325,9 @@
       }
     },
     "@spot.im/react-native-spotim": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@spot.im/react-native-spotim/-/react-native-spotim-1.0.12.tgz",
-      "integrity": "sha512-pPjqVzqH9NFR26DywTIEhRinkMukAwdYA3pQ0+c8puaCsVJWCWISaF9s4ytuOsgFxzUVWlaU8vLc9HrdlkVWqA=="
+      "version": "1.0.13-rc.1",
+      "resolved": "https://registry.npmjs.org/@spot.im/react-native-spotim/-/react-native-spotim-1.0.13-rc.1.tgz",
+      "integrity": "sha512-kwUkaX4jdCRcExjzowPrxysZL7hUW+uYdAtjEEmetlI2dzwIUwD6/Xw52iALQlNMMlAaWop3DCL5I+KZr1zuNg=="
     },
     "@types/babel__core": {
       "version": "7.1.9",

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@spot.im/react-native-spotim": "^1.0.12",
+    "@spot.im/react-native-spotim": "^1.0.13-rc.1",
     "react": "^16.13.1",
     "react-native": "^0.63.2"
   },

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { Dimensions, NativeEventEmitter, NativeModules, Platform, UIManager, findNodeHandle, requireNativeComponent, PixelRatio } from 'react-native';
+import { Dimensions, NativeEventEmitter, NativeModules, PixelRatio, Platform, UIManager, findNodeHandle, requireNativeComponent } from 'react-native';
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -69,22 +69,92 @@ export class SpotIM extends React.Component {
 
 export class SpotIMAPI {
     static init = (spotId) => {
-        return SpotIMModule.initWithSpotId(spotId)
+        SpotIMModule.initWithSpotId(spotId)
     }
     static startSSO = () => {
-        return SpotIMModule.startSSO();
+        return new Promise((resolve, reject) => {
+            const successSubscription = SpotIMEventEmitter.addListener('startSSOSuccess', (response) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                resolve(response);
+            });
+
+            const failureSubscription = SpotIMEventEmitter.addListener('startSSOFailed', (event) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                reject(event);
+            });
+
+            SpotIMModule.startSSO();
+        })
     }
     static completeSSO = (str) => {
-        return SpotIMModule.completeSSO(str);
+        return new Promise((resolve, reject) => {
+            const successSubscription = SpotIMEventEmitter.addListener('completeSSOSuccess', (response) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                resolve(response);
+            });
+
+            const failureSubscription = SpotIMEventEmitter.addListener('completeSSOFailed', (event) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                reject(event);
+            });
+
+            SpotIMModule.completeSSO(str);
+        })
     }
     static sso = (jwt) => {
-        return SpotIMModule.ssoWithJwtSecret(jwt);
+        return new Promise((resolve, reject) => {
+            const successSubscription = SpotIMEventEmitter.addListener('ssoSuccess', (response) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                resolve(response);
+            });
+
+            const failureSubscription = SpotIMEventEmitter.addListener('ssoFailed', (event) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                reject(event);
+            });
+
+            SpotIMModule.ssoWithJwtSecret(jwt);
+        })
     }
     static getUserLoginStatus = () => {
-        return SpotIMModule.getUserLoginStatus();
+        return new Promise((resolve, reject) => {
+            const successSubscription = SpotIMEventEmitter.addListener('getUserLoginStatusSuccess', (response) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                resolve(response);
+            });
+
+            const failureSubscription = SpotIMEventEmitter.addListener('getUserLoginStatusFailed', (event) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                reject(event);
+            });
+
+            SpotIMModule.getUserLoginStatus();
+        })
     }
     static logout = () => {
-        return SpotIMModule.logout();
+        return new Promise((resolve, reject) => {
+            const successSubscription = SpotIMEventEmitter.addListener('logoutSuccess', (response) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                resolve(response);
+            });
+
+            const failureSubscription = SpotIMEventEmitter.addListener('logoutFailed', (event) => {
+                successSubscription.remove();
+                failureSubscription.remove();
+                reject(event);
+            });
+
+            SpotIMModule.logout();
+        })
     }
 }
 

--- a/ios/SpotIMEvents.h
+++ b/ios/SpotIMEvents.h
@@ -13,5 +13,7 @@
 
 - (void)sendLoginEvent;
 - (void)sendViewHeightDidChangeEvent:(NSString*)newHeight;
+- (void)sendRequsetSuccessEvent:(NSString*)eventName response:(NSDictionary *)response;
+- (void)sendRequsetFailedEvent:(NSString*)eventName error:(NSError *)error;
 
 @end

--- a/ios/SpotIMEvents.m
+++ b/ios/SpotIMEvents.m
@@ -23,7 +23,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"startLoginFlow", @"viewHeightDidChange"];
+    return @[@"startLoginFlow", @"viewHeightDidChange", @"startSSOSuccess", @"startSSOFailed", @"completeSSOSuccess", @"completeSSOFailed", @"ssoSuccess", @"ssoFailed", @"getUserLoginStatusSuccess", @"getUserLoginStatusFailed", @"logoutSuccess", @"logoutFailed"];
 }
 
 - (void)sendLoginEvent
@@ -35,4 +35,13 @@ RCT_EXPORT_MODULE();
     [self sendEventWithName:@"viewHeightDidChange" body:@{@"newHeight": newHeight}];
 }
 
+- (void)sendRequsetSuccessEvent:(NSString*)eventName response:(NSDictionary *)response
+{
+    [self sendEventWithName:eventName body:response];
+}
+
+- (void)sendRequsetFailedEvent:(NSString*)eventName error:(NSError *)error
+{
+    [self sendEventWithName:eventName body:@{@"error": error}];
+}
 @end

--- a/ios/SpotIMEvents.m
+++ b/ios/SpotIMEvents.m
@@ -42,6 +42,6 @@ RCT_EXPORT_MODULE();
 
 - (void)sendRequsetFailedEvent:(NSString*)eventName error:(NSError *)error
 {
-    [self sendEventWithName:eventName body:@{@"error": error}];
+    [self sendEventWithName:eventName body:@{@"error": error.localizedDescription}];
 }
 @end

--- a/ios/SpotIMView.h
+++ b/ios/SpotIMView.h
@@ -10,8 +10,8 @@
 
 @interface SpotIMView : UIView
 
-typedef void (^SSOCompletionBlock)(NSString *response);
 typedef void (^SSOErrorBlock)(NSError *error);
+typedef void (^RequestCompletion)(NSDictionary *response);
 
 @property (nonatomic, copy) NSString *spotId;
 @property (nonatomic, copy) NSString *postId;
@@ -22,10 +22,10 @@ typedef void (^SSOErrorBlock)(NSError *error);
 @property (nonatomic, copy) NSString *darkModeBackgroundColor;
 
 - (void)initWithSpotId:(NSString *)spotId;
-- (void)startSSO:(SSOCompletionBlock)completion onError:(SSOErrorBlock)error;
-- (void)completeSSO:(NSString *)with onCompletion:(SSOCompletionBlock)completion onError:(SSOErrorBlock)error;
-- (void)ssoWithJwtSecret:(NSString *)token onCompletion:(SSOCompletionBlock)completion onError:(SSOErrorBlock)error;
-- (void)getUserLoginStatus:(SSOCompletionBlock)completion onError:(SSOErrorBlock)error;
-- (void)logout:(SSOCompletionBlock)completion onError:(SSOErrorBlock)error;
+- (void)startSSO:(RequestCompletion)completion onError:(SSOErrorBlock)error;
+- (void)completeSSO:(NSString *)with onCompletion:(RequestCompletion)completion onError:(SSOErrorBlock)error;
+- (void)ssoWithJwtSecret:(NSString *)token onCompletion:(RequestCompletion)completion onError:(SSOErrorBlock)error;
+- (void)getUserLoginStatus:(RequestCompletion)completion onError:(SSOErrorBlock)error;
+- (void)logout:(RequestCompletion)completion onError:(SSOErrorBlock)error;
 
 @end

--- a/ios/SpotIMView.m
+++ b/ios/SpotIMView.m
@@ -82,9 +82,9 @@ BOOL defaultNavBarVisibilityHidden;
     [spotIm setBackgroundColor:red/255.0 green:green/255.0 blue:blue/255.0 alpha:1.0];
 }
 
-- (void)startSSO:(SSOCompletionBlock)completion
+- (void)startSSO:(RequestCompletion)completion
                   onError:(SSOErrorBlock)error {
-    [spotIm startSSO:^(NSString *response) {
+    [spotIm startSSO:^(NSDictionary *response) {
         completion(response);
     } onError:^(NSError *err) {
         error(err);
@@ -92,9 +92,9 @@ BOOL defaultNavBarVisibilityHidden;
 }
 
 - (void)completeSSO:(NSString *)with
-       onCompletion:(SSOCompletionBlock)completion
+       onCompletion:(RequestCompletion)completion
             onError:(SSOErrorBlock)error {
-    [spotIm completeSSO:with completion:^(NSString * _Nonnull response) {
+    [spotIm completeSSO:with completion:^(NSDictionary * _Nonnull response) {
         completion(response);
     } onError:^(NSError * _Nonnull err) {
         error(err);
@@ -102,27 +102,27 @@ BOOL defaultNavBarVisibilityHidden;
 }
 
 - (void)ssoWithJwtSecret:(NSString *)token
-            onCompletion:(SSOCompletionBlock)completion
+            onCompletion:(RequestCompletion)completion
                  onError:(SSOErrorBlock)error {
-    [spotIm sso:token completion:^(NSString * _Nonnull response) {
+    [spotIm sso:token completion:^(NSDictionary * _Nonnull response) {
         completion(response);
     } onError:^(NSError * _Nonnull err) {
         error(err);
     }];
 }
 
-- (void)getUserLoginStatus:(SSOCompletionBlock)completion
+- (void)getUserLoginStatus:(RequestCompletion)completion
                    onError:(SSOErrorBlock)error {
-    [spotIm getUserLoginStatus:^(NSString * _Nonnull response) {
+    [spotIm getUserLoginStatus:^(NSDictionary * _Nonnull response) {
         completion(response);
     } onError:^(NSError * _Nonnull err) {
         error(err);
     }];
 }
 
-- (void)logout:(SSOCompletionBlock)completion
+- (void)logout:(RequestCompletion)completion
        onError:(SSOErrorBlock)error {
-    [spotIm logout:^(NSString * _Nonnull response) {
+    [spotIm logout:^(NSDictionary * _Nonnull response) {
         completion(response);
     } onError:^(NSError * _Nonnull err) {
         error(err);

--- a/ios/Spotim.m
+++ b/ios/Spotim.m
@@ -47,9 +47,7 @@ RCT_EXPORT_MODULE(SpotIM)
     [spotIMEvents sendViewHeightDidChangeEvent:notification.object];
 }
 
-RCT_EXPORT_METHOD(initWithSpotId:(NSString *)spotId
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(initWithSpotId:(NSString *)spotId) {
     dispatch_async(dispatch_get_main_queue(), ^{
         spotIMEvents = [SpotIMEvents allocWithZone:nil];
         spotIMView = [[SpotIMView alloc] init];
@@ -60,63 +58,56 @@ RCT_EXPORT_METHOD(initWithSpotId:(NSString *)spotId
     });
 }
 
-RCT_EXPORT_METHOD(startSSO:(RCTPromiseResolveBlock)resolve
-                  ejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(startSSO) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [spotIMView startSSO:^(NSString *response) {
-            resolve(response);
+        [spotIMView startSSO:^(NSDictionary *response) {
+            [spotIMEvents sendRequsetSuccessEvent:@"startSSOSuccess" response:response];
         } onError:^(NSError *error) {
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+            [spotIMEvents sendRequsetFailedEvent:@"startSSOFailed" error:error];
             RCTLogInfo(@"RNSpotim: start SSO error: %@ (%ld)", error.localizedDescription, (long)error.code);
         }];
     });
 }
 
-RCT_EXPORT_METHOD(completeSSO:(NSString *)with
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  ejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(completeSSO:(NSString *)codeB) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [spotIMView completeSSO:with onCompletion:^(NSString *response) {
-            resolve(response);
+        [spotIMView completeSSO:codeB onCompletion:^(NSDictionary *response) {
+            [spotIMEvents sendRequsetSuccessEvent:@"completeSSOSuccess" response:response];
         } onError:^(NSError *error) {
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+            [spotIMEvents sendRequsetFailedEvent:@"completeSSOFailed" error:error];
             RCTLogInfo(@"RNSpotim: complete SSO error: %@ (%ld)", error.localizedDescription, (long)error.code);
         }];
     });
 }
 
-RCT_EXPORT_METHOD(ssoWithJwtSecret:(NSString *)token
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  ejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(ssoWithJwtSecret:(NSString *)token) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [spotIMView ssoWithJwtSecret:token onCompletion:^(NSString *response) {
-            resolve(response);
+        [spotIMView ssoWithJwtSecret:token onCompletion:^(NSDictionary *response) {
+            [spotIMEvents sendRequsetSuccessEvent:@"ssoSuccess" response:response];
         } onError:^(NSError *error) {
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+            [spotIMEvents sendRequsetFailedEvent:@"ssoFailed" error:error];
             RCTLogInfo(@"RNSpotim: sso with JWT token error: %@ (%ld)", error.localizedDescription, (long)error.code);
         }];
     });
 }
 
-RCT_EXPORT_METHOD(getUserLoginStatus:(RCTPromiseResolveBlock)resolve
-                             ejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(getUserLoginStatus) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [spotIMView getUserLoginStatus:^(NSString *response) {
-            resolve(response);
+        [spotIMView getUserLoginStatus:^(NSDictionary *response) {
+            [spotIMEvents sendRequsetSuccessEvent:@"getUserLoginStatusSuccess" response:response];
         } onError:^(NSError *error) {
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+            [spotIMEvents sendRequsetFailedEvent:@"getUserLoginStatusFailed" error:error];
             RCTLogInfo(@"RNSpotim: getUserLoginStatus error: %@ (%ld)", error.localizedDescription, (long)error.code);
         }];
     });
 }
 
-RCT_EXPORT_METHOD(logout:(RCTPromiseResolveBlock)resolve
-                 ejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(logout) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [spotIMView logout:^(NSString *response) {
-            resolve(response);
+        [spotIMView logout:^(NSDictionary *response) {
+            [spotIMEvents sendRequsetSuccessEvent:@"logoutSuccess" response:response];
         } onError:^(NSError *error) {
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+            [spotIMEvents sendRequsetFailedEvent:@"logoutFailed" error:error];
             RCTLogInfo(@"RNSpotim: logout error: %@ (%ld)", error.localizedDescription, (long)error.code);
         }];
     });

--- a/ios/Spotim.swift
+++ b/ios/Spotim.swift
@@ -171,7 +171,9 @@ public class SpotImBridge: NSObject, SpotImCore.SpotImLoginDelegate, SpotImCore.
     }
     
     private func dictionary<T>(encodable: T) -> [String: Any]? where T : Encodable {
-        guard let data = try? JSONEncoder().encode(encodable) else { return nil }
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        guard let data = try? encoder.encode(encodable) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
     }
 }


### PR DESCRIPTION
React native was crashing sometimes when iOS native code returned an error. 
The crash was due to multiple calls to the reject callback passed from the native code. 
To avoid this, we now use only events to bridge between RN<->Native instead of passing the promises from the RN.

Changed: 
* Main wrapper index now returns a new promise to avoid multiple calls to the same promise
* Modules now send events to the main wrapper instead of using promises callbacks
* Both APIs (Android + iOS) now return the same structures back to RN, for easier consuming on the RN side